### PR TITLE
Deprecated configuration test failures

### DIFF
--- a/airflow-core/tests/unit/core/test_configuration.py
+++ b/airflow-core/tests/unit/core/test_configuration.py
@@ -65,6 +65,10 @@ conf.deprecated_options[("scheduler", "parsing_cleanup_interval")] = (
     "deactivate_stale_dags_interval",
     "2.5.0",
 )
+# Invalidate cached properties that depend on deprecated_options, since they may have been
+# computed during airflow initialization before the entries above were added.
+for attr in ("sensitive_config_values", "inversed_deprecated_options"):
+    conf.__dict__.pop(attr, None)
 
 
 @pytest.fixture(scope="module", autouse=True)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fix: Invalidate cached config properties in TestDeprecatedConf

The `sensitive_config_values` and `inversed_deprecated_options` cached properties on `AirflowConfigParser` were stale in `TestDeprecatedConf`. These properties are cached during Airflow's initial import, but the test module adds new entries to `conf.deprecated_options` afterwards. This led to `_cmd` and `_secret` values for deprecated options not being correctly processed in `as_dict()`, causing test failures when `TestDeprecatedConf` was run in isolation.

The fix explicitly invalidates these cached properties after `deprecated_options` are modified in the test setup, ensuring the tests use an up-to-date configuration.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude 3.5 Sonnet following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.

---
<p><a href="https://cursor.com/agents/bc-59cd6100-57b4-48fb-a222-1347e747c3f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-59cd6100-57b4-48fb-a222-1347e747c3f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->