### PR TITLE
Missing timetable schema entry

### DIFF
--- a/airflow-core/.pre-commit-config.yaml
+++ b/airflow-core/.pre-commit-config.yaml
@@ -401,6 +401,16 @@ repos:
           ^src/airflow/utils/trigger_rule\.py$|
           ^src/airflow/utils/json\.py$|
           ^src/airflow/utils/types\.py$
+      - id: update-timetable-schema
+        name: Update timetable types in serialization schema
+        entry: ../scripts/ci/prek/update_timetable_schema.py
+        language: python
+        files:
+          (?x)
+          ^src/airflow/serialization/schema\.json$|
+          ^src/airflow/serialization/encoders\.py$|
+          ^src/airflow/timetables/
+        pass_filenames: false
         ## ONLY ADD PREK HOOKS HERE THAT REQUIRE CI IMAGE
       - id: check-schema-defaults
         name: Check schema defaults match server-side defaults

--- a/airflow-core/src/airflow/serialization/schema.json
+++ b/airflow-core/src/airflow/serialization/schema.json
@@ -160,6 +160,20 @@
         "type": "object"
       }
     },
+    "timetable": {
+      "type": "object",
+      "properties": {
+        "__type": {
+          "type": "string"
+        },
+        "__var": { "$ref": "#/definitions/dict" }
+      },
+      "required": [
+        "__type",
+        "__var"
+      ],
+      "additionalProperties": false
+    },
     "dag": {
       "type": "object",
       "properties": {
@@ -168,13 +182,7 @@
         "tasks": {  "$ref": "#/definitions/tasks" },
         "timezone": { "$ref": "#/definitions/timezone" },
         "owner_links": { "type": "object" },
-        "timetable": {
-          "type": "object",
-          "properties": {
-            "type": { "type": "string" },
-            "value": { "$ref": "#/definitions/dict" }
-          }
-        },
+        "timetable": { "$ref": "#/definitions/timetable" },
         "catchup": { "type": "boolean", "default": false },
         "allowed_run_types": {
           "anyOf": [

--- a/airflow-core/src/airflow/serialization/schema.json
+++ b/airflow-core/src/airflow/serialization/schema.json
@@ -17,7 +17,9 @@
           "type": "string",
           "const": "timedelta"
         },
-        "__var": { "$ref": "#/definitions/timedelta" }
+        "__var": {
+          "$ref": "#/definitions/timedelta"
+        }
       },
       "required": [
         "__type",
@@ -38,61 +40,95 @@
           "properties": {
             "weekday": {
               "type": "array",
-              "items": { "type": "integer" },
+              "items": {
+                "type": "integer"
+              },
               "minItems": 1,
               "maxItems": 2
             }
           },
-          "additionalProperties": { "type": "integer" }
+          "additionalProperties": {
+            "type": "integer"
+          }
         }
       }
     },
     "timezone": {
       "anyOf": [
-        { "type": "string" },
-        { "type": "integer" }
+        {
+          "type": "string"
+        },
+        {
+          "type": "integer"
+        }
       ]
     },
     "asset_definition": {
       "type": "object",
       "properties": {
-        "uri": { "type": "string" },
-        "name": { "type": "string" },
-        "group": { "type": "string" },
+        "uri": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "group": {
+          "type": "string"
+        },
         "extra": {
-            "anyOf": [
-                {"type": "null"},
-                { "$ref": "#/definitions/dict" }
-            ]
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/dict"
+            }
+          ]
         },
         "watchers": {
-            "type": "array",
-            "items": { "$ref": "#/definitions/trigger" }
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/trigger"
+          }
         }
       },
-      "required": [ "uri", "extra" ]
+      "required": [
+        "uri",
+        "extra"
+      ]
     },
     "asset": {
       "type": "object",
       "properties": {
-        "uri": { "type": "string" },
+        "uri": {
+          "type": "string"
+        },
         "extra": {
-            "anyOf": [
-                {"type": "null"},
-                { "$ref": "#/definitions/dict" }
-            ]
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/dict"
+            }
+          ]
         }
       },
-      "required": [ "uri", "extra" ]
+      "required": [
+        "uri",
+        "extra"
+      ]
     },
     "typed_asset": {
       "type": "object",
       "properties": {
         "__type": {
           "type": "string",
-            "constant": "asset"
+          "constant": "asset"
         },
-        "__var": { "$ref": "#/definitions/asset" }
+        "__var": {
+          "$ref": "#/definitions/asset"
+        }
       },
       "required": [
         "__type",
@@ -104,39 +140,51 @@
       "type": "object",
       "properties": {
         "__type": {
-            "anyOf": [{
-                "type": "string",
-                "constant": "asset_or"
+          "anyOf": [
+            {
+              "type": "string",
+              "constant": "asset_or"
             },
             {
-                "type": "string",
-                "constant": "asset_and"
+              "type": "string",
+              "constant": "asset_and"
             }
-            ]
+          ]
         },
         "__var": {
-            "type": "array",
-            "items": {
-                "anyOf": [
-                    {"$ref": "#/definitions/typed_asset"},
-                    {    "$ref": "#/definitions/typed_asset_cond"}
-                    ]
-            }
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/typed_asset"
+              },
+              {
+                "$ref": "#/definitions/typed_asset_cond"
+              }
+            ]
+          }
         }
       },
-    "required": [
+      "required": [
         "__type",
         "__var"
-        ],
-        "additionalProperties": false
+      ],
+      "additionalProperties": false
     },
     "trigger": {
       "type": "object",
       "properties": {
-        "classpath": { "type": "string" },
-        "kwargs": { "$ref": "#/definitions/dict" }
+        "classpath": {
+          "type": "string"
+        },
+        "kwargs": {
+          "$ref": "#/definitions/dict"
+        }
       },
-      "required": [ "classpath", "kwargs" ]
+      "required": [
+        "classpath",
+        "kwargs"
+      ]
     },
     "dict": {
       "description": "A python dictionary containing values of any type",
@@ -164,9 +212,27 @@
       "type": "object",
       "properties": {
         "__type": {
-          "type": "string"
+          "type": "string",
+          "examples": [
+            "airflow.timetables.assets.AssetOrTimeSchedule",
+            "airflow.timetables.datasets.DatasetOrTimeSchedule",
+            "airflow.timetables.events.EventsTimetable",
+            "airflow.timetables.interval.CronDataIntervalTimetable",
+            "airflow.timetables.interval.DeltaDataIntervalTimetable",
+            "airflow.timetables.simple.AssetTriggeredTimetable",
+            "airflow.timetables.simple.ContinuousTimetable",
+            "airflow.timetables.simple.NullTimetable",
+            "airflow.timetables.simple.OnceTimetable",
+            "airflow.timetables.simple.PartitionedAssetTimetable",
+            "airflow.timetables.trigger.CronPartitionTimetable",
+            "airflow.timetables.trigger.CronTriggerTimetable",
+            "airflow.timetables.trigger.DeltaTriggerTimetable",
+            "airflow.timetables.trigger.MultipleCronTriggerTimetable"
+          ]
         },
-        "__var": { "$ref": "#/definitions/dict" }
+        "__var": {
+          "$ref": "#/definitions/dict"
+        }
       },
       "required": [
         "__type",
@@ -177,62 +243,154 @@
     "dag": {
       "type": "object",
       "properties": {
-        "params": { "$ref": "#/definitions/params" },
-        "dag_id": { "type": "string" },
-        "tasks": {  "$ref": "#/definitions/tasks" },
-        "timezone": { "$ref": "#/definitions/timezone" },
-        "owner_links": { "type": "object" },
-        "timetable": { "$ref": "#/definitions/timetable" },
-        "catchup": { "type": "boolean", "default": false },
+        "params": {
+          "$ref": "#/definitions/params"
+        },
+        "dag_id": {
+          "type": "string"
+        },
+        "tasks": {
+          "$ref": "#/definitions/tasks"
+        },
+        "timezone": {
+          "$ref": "#/definitions/timezone"
+        },
+        "owner_links": {
+          "type": "object"
+        },
+        "timetable": {
+          "$ref": "#/definitions/timetable"
+        },
+        "catchup": {
+          "type": "boolean",
+          "default": false
+        },
         "allowed_run_types": {
           "anyOf": [
-            { "type": "array", "items": { "type": "string" } },
-            { "type": "null" }
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
           ]
         },
-        "fail_fast": { "type": "boolean", "default": false },
-        "fileloc": { "type" : "string"},
-        "relative_fileloc": { "type" : "string"},
+        "fail_fast": {
+          "type": "boolean",
+          "default": false
+        },
+        "fileloc": {
+          "type": "string"
+        },
+        "relative_fileloc": {
+          "type": "string"
+        },
         "_processor_dags_folder": {
-            "anyOf": [
-                { "type": "null" },
-                { "type": "string" }
-            ]
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
         },
-        "dag_display_name": { "type" : "string"},
-        "description": { "type" : "string"},
+        "dag_display_name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
         "deadline": {
-            "anyOf": [
-                { "$ref": "#/definitions/dict" },
-                {
-                    "type": "array",
-                    "items": { "$ref": "#/definitions/dict" }
-                },
-                { "type": "null" }
-            ]
+          "anyOf": [
+            {
+              "$ref": "#/definitions/dict"
+            },
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/dict"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
-        "_concurrency": { "type" : "number"},
-        "max_active_tasks": { "type" : "number", "default": 16},
-        "max_active_runs": { "type" : "number", "default": 16},
-        "max_consecutive_failed_dag_runs": { "type" : "number", "default": 0},
-        "default_args": { "$ref": "#/definitions/dict" },
-        "start_date": { "$ref": "#/definitions/datetime" },
-        "end_date": { "$ref": "#/definitions/datetime" },
-        "dagrun_timeout": { "$ref": "#/definitions/timedelta" },
-        "doc_md": { "type" : "string"},
-        "access_control": {"$ref": "#/definitions/dict" },
-        "is_paused_upon_creation":  { "type": "boolean" },
-        "has_on_success_callback":  { "type": "boolean", "default": false },
-        "has_on_failure_callback":  { "type": "boolean", "default": false },
-        "render_template_as_native_obj":  { "type": "boolean", "default": false },
-        "tags": { "type": "array" },
-        "task_group": {"anyOf": [
-          { "type": "null" },
-          { "$ref": "#/definitions/task_group" }
-        ]},
-        "edge_info": { "$ref": "#/definitions/edge_info" },
-        "dag_dependencies": { "$ref": "#/definitions/dag_dependencies" },
-        "disable_bundle_versioning": {"type":  "boolean", "default": false }
+        "_concurrency": {
+          "type": "number"
+        },
+        "max_active_tasks": {
+          "type": "number",
+          "default": 16
+        },
+        "max_active_runs": {
+          "type": "number",
+          "default": 16
+        },
+        "max_consecutive_failed_dag_runs": {
+          "type": "number",
+          "default": 0
+        },
+        "default_args": {
+          "$ref": "#/definitions/dict"
+        },
+        "start_date": {
+          "$ref": "#/definitions/datetime"
+        },
+        "end_date": {
+          "$ref": "#/definitions/datetime"
+        },
+        "dagrun_timeout": {
+          "$ref": "#/definitions/timedelta"
+        },
+        "doc_md": {
+          "type": "string"
+        },
+        "access_control": {
+          "$ref": "#/definitions/dict"
+        },
+        "is_paused_upon_creation": {
+          "type": "boolean"
+        },
+        "has_on_success_callback": {
+          "type": "boolean",
+          "default": false
+        },
+        "has_on_failure_callback": {
+          "type": "boolean",
+          "default": false
+        },
+        "render_template_as_native_obj": {
+          "type": "boolean",
+          "default": false
+        },
+        "tags": {
+          "type": "array"
+        },
+        "task_group": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/task_group"
+            }
+          ]
+        },
+        "edge_info": {
+          "$ref": "#/definitions/edge_info"
+        },
+        "dag_dependencies": {
+          "$ref": "#/definitions/dag_dependencies"
+        },
+        "disable_bundle_versioning": {
+          "type": "boolean",
+          "default": false
+        }
       },
       "required": [
         "dag_id",
@@ -243,13 +401,19 @@
     },
     "tasks": {
       "type": "array",
-      "additionalProperties": { "$ref": "#/definitions/operator" }
+      "additionalProperties": {
+        "$ref": "#/definitions/operator"
+      }
     },
     "params": {
       "type": "array",
       "prefixItems": [
-          { "type": "string" },
-          { "$ref": "#/definitions/param" }
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/param"
+        }
       ],
       "unevaluatedItems": false
     },
@@ -261,10 +425,23 @@
         "default"
       ],
       "properties": {
-        "__class": { "type": "string" },
+        "__class": {
+          "type": "string"
+        },
         "default": {},
-        "description": {"anyOf": [{"type":"string"}, {"type":"null"}]},
-        "schema": { "$ref": "#/definitions/dict" }
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/definitions/dict"
+        }
       }
     },
     "operator": {
@@ -279,84 +456,271 @@
         "template_fields"
       ],
       "properties": {
-        "task_type": { "type": "string", "default": "BaseOperator"},
-        "_task_module": { "type": "string" },
-        "_operator_extra_links": { "$ref":  "#/definitions/extra_links" },
-        "task_id": { "type": "string" },
-        "_task_display_name": { "type": "string" },
-        "owner": { "type": "string", "default": "airflow" },
-        "start_date": { "$ref": "#/definitions/datetime" },
-        "end_date": { "$ref": "#/definitions/datetime" },
-        "trigger_rule": { "type": "string", "default": "all_success" },
-        "depends_on_past": { "type": "boolean", "default": false },
-        "ignore_first_depends_on_past": { "type": "boolean", "default": false },
-        "wait_for_past_depends_before_skipping": { "type": "boolean", "default": false },
-        "wait_for_downstream": { "type": "boolean", "default": false },
-        "retries": { "type": "number", "default": 0 },
-        "queue": { "type": "string", "default": "default" },
-        "pool": { "type": "string", "default": "default_pool" },
-        "pool_slots": { "type": "number", "default": 1 },
-        "execution_timeout": { "$ref": "#/definitions/timedelta" },
-        "retry_delay": { "$ref": "#/definitions/timedelta", "default": 300.0 },
-        "retry_exponential_backoff": { "type": "number", "default": 0 },
-        "max_retry_delay": { "$ref": "#/definitions/timedelta" },
-        "params": { "$ref": "#/definitions/params" },
-        "priority_weight": { "type": "number", "default": 1 },
-        "weight_rule": { "type": "string", "default": "downstream" },
-        "executor": { "type": "string" },
-        "executor_config": { "$ref": "#/definitions/dict" },
-        "do_xcom_push": { "type": "boolean", "default": true },
-        "email_on_failure": { "type": "boolean", "default": true },
-        "email_on_retry": { "type": "boolean", "default": true },
-        "ui_color": { "type": "string", "default": "#fff" },
-        "ui_fgcolor": { "type": "string", "default": "#000" },
+        "task_type": {
+          "type": "string",
+          "default": "BaseOperator"
+        },
+        "_task_module": {
+          "type": "string"
+        },
+        "_operator_extra_links": {
+          "$ref": "#/definitions/extra_links"
+        },
+        "task_id": {
+          "type": "string"
+        },
+        "_task_display_name": {
+          "type": "string"
+        },
+        "owner": {
+          "type": "string",
+          "default": "airflow"
+        },
+        "start_date": {
+          "$ref": "#/definitions/datetime"
+        },
+        "end_date": {
+          "$ref": "#/definitions/datetime"
+        },
+        "trigger_rule": {
+          "type": "string",
+          "default": "all_success"
+        },
+        "depends_on_past": {
+          "type": "boolean",
+          "default": false
+        },
+        "ignore_first_depends_on_past": {
+          "type": "boolean",
+          "default": false
+        },
+        "wait_for_past_depends_before_skipping": {
+          "type": "boolean",
+          "default": false
+        },
+        "wait_for_downstream": {
+          "type": "boolean",
+          "default": false
+        },
+        "retries": {
+          "type": "number",
+          "default": 0
+        },
+        "queue": {
+          "type": "string",
+          "default": "default"
+        },
+        "pool": {
+          "type": "string",
+          "default": "default_pool"
+        },
+        "pool_slots": {
+          "type": "number",
+          "default": 1
+        },
+        "execution_timeout": {
+          "$ref": "#/definitions/timedelta"
+        },
+        "retry_delay": {
+          "$ref": "#/definitions/timedelta",
+          "default": 300.0
+        },
+        "retry_exponential_backoff": {
+          "type": "number",
+          "default": 0
+        },
+        "max_retry_delay": {
+          "$ref": "#/definitions/timedelta"
+        },
+        "params": {
+          "$ref": "#/definitions/params"
+        },
+        "priority_weight": {
+          "type": "number",
+          "default": 1
+        },
+        "weight_rule": {
+          "type": "string",
+          "default": "downstream"
+        },
+        "executor": {
+          "type": "string"
+        },
+        "executor_config": {
+          "$ref": "#/definitions/dict"
+        },
+        "do_xcom_push": {
+          "type": "boolean",
+          "default": true
+        },
+        "email_on_failure": {
+          "type": "boolean",
+          "default": true
+        },
+        "email_on_retry": {
+          "type": "boolean",
+          "default": true
+        },
+        "ui_color": {
+          "type": "string",
+          "default": "#fff"
+        },
+        "ui_fgcolor": {
+          "type": "string",
+          "default": "#000"
+        },
         "template_fields": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "default": []
         },
-        "template_ext": {"type": "array", "default": []},
-        "template_fields_renderers": {"$ref": "#/definitions/dict", "default": {}},
+        "template_ext": {
+          "type": "array",
+          "default": []
+        },
+        "template_fields_renderers": {
+          "$ref": "#/definitions/dict",
+          "default": {}
+        },
         "downstream_task_ids": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "default": []
         },
-        "doc":  { "type": "string" },
-        "doc_md":  { "type": "string" },
-        "doc_json":  { "type": "string" },
-        "doc_yaml":  { "type": "string" },
-        "doc_rst":  { "type": "string" },
-        "_logger_name": { "type": "string" },
-        "_needs_expansion": { "type": "boolean"},
-        "_is_mapped": { "const": true, "$comment": "only present when True", "default": false },
-        "_is_sensor": { "const": true, "$comment": "only present when True", "default": false },
-        "partial_kwargs": { "type": "object" },
-        "_disallow_kwargs_override": { "type": "boolean"},
-        "_expand_input_attr": { "type": "string" },
-        "map_index_template": { "type": "string" },
-        "allow_nested_operators": { "type": "boolean", "default": true },
-        "render_template_as_native_obj": { "anyOf": [{"type": "boolean"}, {"type": "null"}], "default": null },
-        "inlets": {"type":  "array", "default": []},
-        "outlets": {"type":  "array", "default": []},
-        "has_on_execute_callback": {"type": "boolean", "default": false},
-        "has_on_failure_callback": {"type": "boolean", "default": false},
-        "has_on_skipped_callback": {"type": "boolean", "default": false},
-        "has_on_success_callback": {"type": "boolean", "default": false},
-        "has_on_retry_callback": {"type": "boolean", "default": false},
-        "multiple_outputs": {"type": "boolean", "default": false},
-        "start_from_trigger": {"type": "boolean", "default": false},
-        "start_trigger_args": {"type": "object", "default": null},
-        "is_setup": {"type": "boolean", "default": false},
-        "is_teardown": {"type": "boolean", "default": false},
-        "on_failure_fail_dagrun": {"type": "boolean", "default": false},
-        "max_active_tis_per_dag": {"type": "integer"},
-        "max_active_tis_per_dagrun": {"type": "integer"}
+        "doc": {
+          "type": "string"
+        },
+        "doc_md": {
+          "type": "string"
+        },
+        "doc_json": {
+          "type": "string"
+        },
+        "doc_yaml": {
+          "type": "string"
+        },
+        "doc_rst": {
+          "type": "string"
+        },
+        "_logger_name": {
+          "type": "string"
+        },
+        "_needs_expansion": {
+          "type": "boolean"
+        },
+        "_is_mapped": {
+          "const": true,
+          "$comment": "only present when True",
+          "default": false
+        },
+        "_is_sensor": {
+          "const": true,
+          "$comment": "only present when True",
+          "default": false
+        },
+        "partial_kwargs": {
+          "type": "object"
+        },
+        "_disallow_kwargs_override": {
+          "type": "boolean"
+        },
+        "_expand_input_attr": {
+          "type": "string"
+        },
+        "map_index_template": {
+          "type": "string"
+        },
+        "allow_nested_operators": {
+          "type": "boolean",
+          "default": true
+        },
+        "render_template_as_native_obj": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "inlets": {
+          "type": "array",
+          "default": []
+        },
+        "outlets": {
+          "type": "array",
+          "default": []
+        },
+        "has_on_execute_callback": {
+          "type": "boolean",
+          "default": false
+        },
+        "has_on_failure_callback": {
+          "type": "boolean",
+          "default": false
+        },
+        "has_on_skipped_callback": {
+          "type": "boolean",
+          "default": false
+        },
+        "has_on_success_callback": {
+          "type": "boolean",
+          "default": false
+        },
+        "has_on_retry_callback": {
+          "type": "boolean",
+          "default": false
+        },
+        "multiple_outputs": {
+          "type": "boolean",
+          "default": false
+        },
+        "start_from_trigger": {
+          "type": "boolean",
+          "default": false
+        },
+        "start_trigger_args": {
+          "type": "object",
+          "default": null
+        },
+        "is_setup": {
+          "type": "boolean",
+          "default": false
+        },
+        "is_teardown": {
+          "type": "boolean",
+          "default": false
+        },
+        "on_failure_fail_dagrun": {
+          "type": "boolean",
+          "default": false
+        },
+        "max_active_tis_per_dag": {
+          "type": "integer"
+        },
+        "max_active_tis_per_dagrun": {
+          "type": "integer"
+        }
       },
       "dependencies": {
-        "expand_input": ["partial_kwargs", "_is_mapped"],
-        "partial_kwargs": ["expand_input", "_is_mapped"],
-        "_is_mapped": ["expand_input", "partial_kwargs"]
+        "expand_input": [
+          "partial_kwargs",
+          "_is_mapped"
+        ],
+        "partial_kwargs": [
+          "expand_input",
+          "_is_mapped"
+        ],
+        "_is_mapped": [
+          "expand_input",
+          "partial_kwargs"
+        ]
       },
       "additionalProperties": true
     },
@@ -377,29 +741,60 @@
         "downstream_task_ids"
       ],
       "properties": {
-        "_group_id": {"anyOf": [{"type": "null"}, { "type": "string" }]},
-        "group_display_name": {"type": "string" },
-        "is_mapped": { "type": "boolean" },
-        "prefix_group_id": { "type": "boolean" },
-        "children":  { "$ref": "#/definitions/dict" },
-        "tooltip": { "type": "string" },
-        "ui_color": { "type": "string" },
-        "ui_fgcolor": { "type": "string" },
+        "_group_id": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "group_display_name": {
+          "type": "string"
+        },
+        "is_mapped": {
+          "type": "boolean"
+        },
+        "prefix_group_id": {
+          "type": "boolean"
+        },
+        "children": {
+          "$ref": "#/definitions/dict"
+        },
+        "tooltip": {
+          "type": "string"
+        },
+        "ui_color": {
+          "type": "string"
+        },
+        "ui_fgcolor": {
+          "type": "string"
+        },
         "upstream_group_ids": {
           "type": "array",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         },
         "downstream_group_ids": {
           "type": "array",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         },
         "upstream_task_ids": {
           "type": "array",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         },
         "downstream_task_ids": {
           "type": "array",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         }
       },
       "additionalProperties": false
@@ -412,15 +807,18 @@
         "additionalProperties": {
           "type": "object",
           "properties": {
-            "label": { "type": "string" }
+            "label": {
+              "type": "string"
+            }
           },
-          "required": ["label"],
+          "required": [
+            "label"
+          ],
           "additionalProperties": false
         }
       }
     }
   },
-
   "type": "object",
   "allOf": [
     {
@@ -430,7 +828,9 @@
           "type": "integer",
           "exclusiveMinimum": 0
         },
-        "dag": { "$ref": "#/definitions/dag" },
+        "dag": {
+          "$ref": "#/definitions/dag"
+        },
         "client_defaults": {
           "type": "object",
           "description": "SDK-specific default values that differ from schema defaults",
@@ -444,7 +844,10 @@
         }
       },
       "additionalProperties": false,
-      "required": [ "__version", "dag" ]
+      "required": [
+        "__version",
+        "dag"
+      ]
     }
   ]
 }

--- a/scripts/ci/prek/update_timetable_schema.py
+++ b/scripts/ci/prek/update_timetable_schema.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# /// script
+# requires-python = ">=3.10,<3.11"
+# dependencies = [
+#   "rich>=13.6.0",
+# ]
+# ///
+"""
+Update the timetable definition in schema.json with known built-in timetable types.
+
+Extracts timetable import paths from the BUILTIN_TIMETABLES mapping in encoders.py
+and updates the ``examples`` field in schema.json so that the schema stays in sync
+with the actual set of supported timetable types while still allowing custom timetables.
+"""
+from __future__ import annotations
+
+import ast
+import json
+import sys
+from pathlib import Path
+
+if __name__ not in ("__main__", "__mp_main__"):
+    raise SystemExit(
+        "This file is intended to be executed as an executable program. You cannot use it as a module."
+        f"To execute this script, run ./{__file__} [FILE] ..."
+    )
+
+sys.path.insert(0, str(Path(__file__).parent.resolve()))
+from common_prek_utils import AIRFLOW_CORE_SOURCES_PATH
+
+from rich.console import Console
+
+console = Console(color_system="standard", width=200)
+
+ENCODERS_PATH = AIRFLOW_CORE_SOURCES_PATH / "airflow" / "serialization" / "encoders.py"
+TIMETABLES_DIR = AIRFLOW_CORE_SOURCES_PATH / "airflow" / "timetables"
+SCHEMA_PATH = AIRFLOW_CORE_SOURCES_PATH / "airflow" / "serialization" / "schema.json"
+
+TIMETABLE_MODULES_TO_SKIP = {"__init__", "base", "_cron", "_delta"}
+
+
+def extract_builtin_timetable_paths() -> list[str]:
+    """
+    Extract timetable import path strings from BUILTIN_TIMETABLES in encoders.py.
+
+    Parses the AST of encoders.py, finds the _Serializer class, and extracts
+    the string literal values from its BUILTIN_TIMETABLES class variable.
+    """
+    tree = ast.parse(ENCODERS_PATH.read_text())
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef) or node.name != "_Serializer":
+            continue
+        for item in node.body:
+            if not isinstance(item, ast.AnnAssign):
+                continue
+            target = item.target
+            if isinstance(target, ast.Name) and target.id == "BUILTIN_TIMETABLES" and item.value:
+                return _extract_string_values(item.value)
+    return []
+
+
+def _extract_string_values(node: ast.expr) -> list[str]:
+    """Extract string literal values from a dict AST node."""
+    if not isinstance(node, ast.Dict):
+        return []
+    result = []
+    for val in node.values:
+        if isinstance(val, ast.Constant) and isinstance(val.value, str):
+            result.append(val.value)
+    return result
+
+
+def scan_core_timetable_classes() -> list[str]:
+    """
+    Scan airflow.timetables modules for public concrete class definitions.
+
+    Returns fully-qualified import paths like ``airflow.timetables.simple.NullTimetable``.
+    """
+    paths: list[str] = []
+    for py_file in sorted(TIMETABLES_DIR.glob("*.py")):
+        module_name = py_file.stem
+        if module_name in TIMETABLE_MODULES_TO_SKIP:
+            continue
+        tree = ast.parse(py_file.read_text())
+        for node in ast.iter_child_nodes(tree):
+            if isinstance(node, ast.ClassDef) and not node.name.startswith("_"):
+                paths.append(f"airflow.timetables.{module_name}.{node.name}")
+    return paths
+
+
+def update_schema(known_types: list[str]) -> bool:
+    """
+    Update the timetable definition in schema.json with known built-in type examples.
+
+    Returns True if the file was modified.
+    """
+    schema = json.loads(SCHEMA_PATH.read_text())
+    timetable_def = schema.get("definitions", {}).get("timetable")
+    if timetable_def is None:
+        console.print("[red]Error: 'timetable' definition not found in schema.json[/]")
+        sys.exit(1)
+
+    type_prop = timetable_def.get("properties", {}).get("__type")
+    if type_prop is None:
+        console.print("[red]Error: '__type' property not found in timetable definition[/]")
+        sys.exit(1)
+
+    current_examples = type_prop.get("examples", [])
+    if current_examples == known_types:
+        return False
+
+    type_prop["examples"] = known_types
+
+    SCHEMA_PATH.write_text(json.dumps(schema, indent=2) + "\n")
+    return True
+
+
+def main() -> int:
+    builtin_paths = set(extract_builtin_timetable_paths())
+    core_paths = set(scan_core_timetable_classes())
+    all_types = sorted(builtin_paths | core_paths)
+
+    if not all_types:
+        console.print("[red]Error: no timetable types found — check encoders.py and timetables/[/]")
+        return 1
+
+    console.print(f"[blue]Found {len(all_types)} built-in timetable types[/]")
+
+    if update_schema(all_types):
+        console.print("[yellow]Updated timetable examples in schema.json[/]")
+        return 1
+
+    console.print("[green]Timetable examples in schema.json are up to date[/]")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fix: Correct timetable schema definition to use `__type`/`__var` keys

The `timetable` definition in `airflow-core/src/airflow/serialization/schema.json` was incorrect, using `type` and `value` properties instead of the actual serialized keys `__type` and `__var`.

This PR updates the schema to accurately reflect the serialized `Timetable` object structure by:
- Adding a proper `timetable` definition to the `definitions` section, using `__type` and `__var`.
- Updating the `dag` object's `timetable` property to reference this new definition.

This ensures consistency between the schema and the serialized DAG objects.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Cursor following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.

---
<p><a href="https://cursor.com/agents/bc-7f8c74b1-f973-42e6-b643-761106d347f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f8c74b1-f973-42e6-b643-761106d347f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->