### PR TITLE
Consumer dag partitioned runs tab

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/assets.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/assets.py
@@ -55,7 +55,7 @@ def next_run_assets(
     pending_partition_count: int | None = None
 
     queued_expr: ColumnElement[int]
-    if is_partitioned := dag_model.timetable_summary == "Partitioned Asset":
+    if is_partitioned := bool(dag_model.timetable_partitioned):
         pending_partition_count = session.scalar(
             select(func.count())
             .select_from(AssetPartitionDagRun)

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/assets.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/assets.py
@@ -55,7 +55,7 @@ def next_run_assets(
     pending_partition_count: int | None = None
 
     queued_expr: ColumnElement[int]
-    if is_partitioned := bool(dag_model.timetable_partitioned):
+    if is_partitioned := dag_model.timetable_partitioned:
         pending_partition_count = session.scalar(
             select(func.count())
             .select_from(AssetPartitionDagRun)

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/partitioned_dag_runs.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/partitioned_dag_runs.py
@@ -71,7 +71,7 @@ def get_partitioned_dag_runs(
         # Single query: validate Dag + get required count
         dag_info = session.execute(
             select(
-                DagModel.timetable_summary,
+                DagModel.timetable_partitioned,
                 func.count(DagScheduleAssetReference.asset_id).label("required_count"),
             )
             .outerjoin(
@@ -87,7 +87,7 @@ def get_partitioned_dag_runs(
 
         if dag_info is None:
             raise HTTPException(status.HTTP_404_NOT_FOUND, f"Dag with id {dag_id.value} was not found")
-        if dag_info.timetable_summary != "Partitioned Asset":
+        if not dag_info.timetable_partitioned:
             return PartitionedDagRunCollectionResponse(partitioned_dag_runs=[], total=0)
 
         required_count = dag_info.required_count

--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/dag.json
@@ -176,6 +176,7 @@
     "mappedTaskInstances_one": "Task Instance [{{count}}]",
     "mappedTaskInstances_other": "Task Instances [{{count}}]",
     "overview": "Overview",
+    "partitionedRuns": "Partitioned Runs",
     "renderedTemplates": "Rendered Templates",
     "requiredActions": "Required Actions",
     "runs": "Runs",

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Dag.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Dag.tsx
@@ -19,7 +19,7 @@
 import { ReactFlowProvider } from "@xyflow/react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { FiBarChart, FiCode, FiUser, FiCalendar } from "react-icons/fi";
+import { FiBarChart, FiCode, FiDatabase, FiUser, FiCalendar } from "react-icons/fi";
 import { LuChartColumn } from "react-icons/lu";
 import { MdDetails, MdOutlineEventNote } from "react-icons/md";
 import { RiArrowGoBackFill } from "react-icons/ri";
@@ -47,6 +47,7 @@ export const Dag = () => {
   const tabs = [
     { icon: <LuChartColumn />, label: translate("tabs.overview"), value: "" },
     { icon: <FiBarChart />, label: translate("tabs.runs"), value: "runs" },
+    { icon: <FiDatabase />, label: translate("tabs.partitionedRuns"), value: "partitioned_runs" },
     { icon: <TaskIcon />, label: translate("tabs.tasks"), value: "tasks" },
     { icon: <FiCalendar />, label: translate("tabs.calendar"), value: "calendar" },
     { icon: <FiUser />, label: translate("tabs.requiredActions"), value: "required_actions" },
@@ -115,6 +116,10 @@ export const Dag = () => {
 
   const displayTabs = processedTabs.filter((tab) => {
     if (dag?.timetable_summary === null && tab.value === "backfills") {
+      return false;
+    }
+
+    if (!dag?.timetable_partitioned && tab.value === "partitioned_runs") {
       return false;
     }
 

--- a/airflow-core/src/airflow/ui/src/pages/Dag/PartitionedRuns/PartitionedRuns.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/PartitionedRuns/PartitionedRuns.tsx
@@ -1,0 +1,133 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Badge, Box, Link, Text } from "@chakra-ui/react";
+import type { ColumnDef } from "@tanstack/react-table";
+import type { TFunction } from "i18next";
+import { useTranslation } from "react-i18next";
+import { Link as RouterLink, useParams } from "react-router-dom";
+
+import { usePartitionedDagRunServiceGetPartitionedDagRuns } from "openapi/queries";
+import type { DagRunState, PartitionedDagRunResponse } from "openapi/requests/types.gen";
+import { AssetProgressCell } from "src/components/AssetProgressCell";
+import { DataTable } from "src/components/DataTable";
+import { useTableURLState } from "src/components/DataTable/useTableUrlState";
+import { ErrorAlert } from "src/components/ErrorAlert";
+import { StateBadge } from "src/components/StateBadge";
+import Time from "src/components/Time";
+
+const dagRunStates = new Set<string>(["queued", "running", "success", "failed"]);
+
+const StateCell = ({ state }: { readonly state: string | null }) => {
+  if (state !== null && dagRunStates.has(state)) {
+    return <StateBadge state={state as DagRunState}>{state}</StateBadge>;
+  }
+
+  return (
+    <Badge borderRadius="full" fontSize="sm" px={2} py={1} variant="outline">
+      {state ?? ""}
+    </Badge>
+  );
+};
+
+const getColumns = (
+  translate: TFunction,
+  dagId: string,
+): Array<ColumnDef<PartitionedDagRunResponse>> => [
+  {
+    accessorKey: "partition_key",
+    enableSorting: false,
+    header: translate("dagRun.mappedPartitionKey"),
+  },
+  {
+    accessorKey: "state",
+    cell: ({ row: { original } }) => <StateCell state={original.state} />,
+    enableSorting: false,
+    header: translate("state"),
+  },
+  {
+    accessorKey: "created_at",
+    cell: ({ row }) => (
+      <Text>
+        <Time datetime={row.original.created_at} />
+      </Text>
+    ),
+    enableSorting: false,
+    header: translate("table.createdAt"),
+  },
+  {
+    accessorKey: "total_received",
+    cell: ({ row }) =>
+      row.original.created_dag_run_id === undefined || row.original.created_dag_run_id === "" ? (
+        <AssetProgressCell
+          dagId={dagId}
+          partitionKey={row.original.partition_key}
+          totalReceived={row.original.total_received}
+          totalRequired={row.original.total_required}
+        />
+      ) : (
+        <Text>{`${String(row.original.total_received)} / ${String(row.original.total_required)}`}</Text>
+      ),
+    enableSorting: false,
+    header: translate("partitionedDagRunDetail.receivedAssetEvents"),
+  },
+  {
+    accessorKey: "created_dag_run_id",
+    cell: ({ row: { original } }) =>
+      original.created_dag_run_id !== undefined && original.created_dag_run_id !== "" ? (
+        <Link asChild color="fg.info">
+          <RouterLink to={`/dags/${original.dag_id}/runs/${original.created_dag_run_id}`}>
+            {original.created_dag_run_id}
+          </RouterLink>
+        </Link>
+      ) : undefined,
+    enableSorting: false,
+    header: translate("dagRunId"),
+  },
+];
+
+export const PartitionedRuns = () => {
+  const { t: translate } = useTranslation();
+  const { dagId } = useParams();
+  const resolvedDagId = dagId ?? "";
+  const { setTableURLState, tableURLState } = useTableURLState();
+
+  const { data, error, isFetching, isLoading } = usePartitionedDagRunServiceGetPartitionedDagRuns({
+    dagId: resolvedDagId,
+  });
+
+  const partitionedDagRuns = data?.partitioned_dag_runs ?? [];
+  const total = data?.total ?? 0;
+  const columns = getColumns(translate, resolvedDagId);
+
+  return (
+    <Box>
+      <ErrorAlert error={error} />
+      <DataTable
+        columns={columns}
+        data={partitionedDagRuns}
+        initialState={tableURLState}
+        isFetching={isFetching}
+        isLoading={isLoading}
+        modelName="common:partitionedDagRun"
+        onStateChange={setTableURLState}
+        total={total}
+      />
+    </Box>
+  );
+};

--- a/airflow-core/src/airflow/ui/src/pages/Dag/PartitionedRuns/PartitionedRuns.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/PartitionedRuns/PartitionedRuns.tsx
@@ -73,15 +73,16 @@ const getColumns = (
   {
     accessorKey: "total_received",
     cell: ({ row }) =>
-      row.original.created_dag_run_id === undefined || row.original.created_dag_run_id === "" ? (
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+      row.original.created_dag_run_id ? (
+        <Text>{`${String(row.original.total_received)} / ${String(row.original.total_required)}`}</Text>
+      ) : (
         <AssetProgressCell
           dagId={dagId}
           partitionKey={row.original.partition_key}
           totalReceived={row.original.total_received}
           totalRequired={row.original.total_required}
         />
-      ) : (
-        <Text>{`${String(row.original.total_received)} / ${String(row.original.total_required)}`}</Text>
       ),
     enableSorting: false,
     header: translate("partitionedDagRunDetail.receivedAssetEvents"),
@@ -89,7 +90,8 @@ const getColumns = (
   {
     accessorKey: "created_dag_run_id",
     cell: ({ row: { original } }) =>
-      original.created_dag_run_id !== undefined && original.created_dag_run_id !== "" ? (
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+      original.created_dag_run_id ? (
         <Link asChild color="fg.info">
           <RouterLink to={`/dags/${original.dag_id}/runs/${original.created_dag_run_id}`}>
             {original.created_dag_run_id}

--- a/airflow-core/src/airflow/ui/src/pages/Dag/PartitionedRuns/index.ts
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/PartitionedRuns/index.ts
@@ -1,0 +1,20 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export { PartitionedRuns } from "./PartitionedRuns";

--- a/airflow-core/src/airflow/ui/src/router.tsx
+++ b/airflow-core/src/airflow/ui/src/router.tsx
@@ -29,6 +29,7 @@ import { Configs } from "src/pages/Configs";
 import { Connections } from "src/pages/Connections";
 import { Dag } from "src/pages/Dag";
 import { Backfills } from "src/pages/Dag/Backfills";
+import { PartitionedRuns } from "src/pages/Dag/PartitionedRuns";
 import { Calendar } from "src/pages/Dag/Calendar/Calendar";
 import { Code } from "src/pages/Dag/Code";
 import { Details as DagDetails } from "src/pages/Dag/Details";
@@ -166,6 +167,7 @@ export const routerConfig = [
         children: [
           { element: <Overview />, index: true },
           { element: <DagRuns />, path: "runs" },
+          { element: <PartitionedRuns />, path: "partitioned_runs" },
           { element: <Tasks />, path: "tasks" },
           { element: <Calendar />, path: "calendar" },
           { element: <HITLTaskInstances />, path: "required_actions" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes: #62564

### Problem

The "Partitioned Runs" tab was not displayed on the DAG page for consumer DAGs or any partitioned DAGs. The backend API used a fragile string comparison (`timetable_summary == "Partitioned Asset"`) to detect partitioned DAGs, which was inconsistent with recent scheduler and asset manager fixes.

### Solution

This PR introduces the "Partitioned Runs" tab to the DAG detail page for all partitioned DAGs and updates the backend logic to correctly identify them.

**Backend Changes:**

- Replaced the `timetable_summary == "Partitioned Asset"` check with `dag_info.timetable_partitioned` in `partitioned_dag_runs.py` and `assets.py`. This aligns with the boolean flag used elsewhere for partitioned DAG detection.

**Frontend Changes:**

- Created a new `PartitionedRuns` page component to display `AssetPartitionDagRun` data.
- Added the "Partitioned Runs" tab to `Dag.tsx`, which is conditionally visible based on `dag.timetable_partitioned`.
- Added the corresponding route in `router.tsx` and an i18n translation key.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: [Cursor] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

<div><a href="https://cursor.com/agents/bc-1e0ff49a-ae0c-430b-b5e2-1ad3dc6854b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e0ff49a-ae0c-430b-b5e2-1ad3dc6854b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->