### PR TITLE
Airflow migrations foreign keys

### DIFF
--- a/airflow-core/src/airflow/migrations/versions/0017_2_9_2_fix_inconsistency_between_ORM_and_migration_files.py
+++ b/airflow-core/src/airflow/migrations/versions/0017_2_9_2_fix_inconsistency_between_ORM_and_migration_files.py
@@ -27,6 +27,8 @@ Create Date: 2024-04-15 14:19:49.913797
 
 from __future__ import annotations
 
+import contextlib
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy import literal
@@ -77,30 +79,31 @@ def upgrade():
         # SQLite does not support DROP CONSTRAINT
         # We have to recreate the table without the constraint
         conn.execute(sa.text("PRAGMA foreign_keys=off"))
-        conn.execute(
-            sa.text("""
-        CREATE TABLE connection_new (
-                id INTEGER NOT NULL,
-                conn_id VARCHAR(250) NOT NULL,
-                conn_type VARCHAR(500) NOT NULL,
-                host VARCHAR(500),
-                schema VARCHAR(500),
-                login TEXT,
-                password TEXT,
-                port INTEGER,
-                extra TEXT,
-                is_encrypted BOOLEAN,
-                is_extra_encrypted BOOLEAN,
-                description VARCHAR(5000),
-                CONSTRAINT connection_pkey PRIMARY KEY (id),
-                CONSTRAINT connection_conn_id_uq UNIQUE (conn_id)
-        )
-        """)
-        )
-        conn.execute(sa.text("INSERT INTO connection_new SELECT * FROM connection"))
-        conn.execute(sa.text("DROP TABLE connection"))
-        conn.execute(sa.text("ALTER TABLE connection_new RENAME TO connection"))
-        conn.execute(sa.text("PRAGMA foreign_keys=on"))
+        with contextlib.ExitStack() as exitstack:
+            exitstack.callback(conn.execute, sa.text("PRAGMA foreign_keys=on"))
+            conn.execute(
+                sa.text("""
+            CREATE TABLE connection_new (
+                    id INTEGER NOT NULL,
+                    conn_id VARCHAR(250) NOT NULL,
+                    conn_type VARCHAR(500) NOT NULL,
+                    host VARCHAR(500),
+                    schema VARCHAR(500),
+                    login TEXT,
+                    password TEXT,
+                    port INTEGER,
+                    extra TEXT,
+                    is_encrypted BOOLEAN,
+                    is_extra_encrypted BOOLEAN,
+                    description VARCHAR(5000),
+                    CONSTRAINT connection_pkey PRIMARY KEY (id),
+                    CONSTRAINT connection_conn_id_uq UNIQUE (conn_id)
+            )
+            """)
+            )
+            conn.execute(sa.text("INSERT INTO connection_new SELECT * FROM connection"))
+            conn.execute(sa.text("DROP TABLE connection"))
+            conn.execute(sa.text("ALTER TABLE connection_new RENAME TO connection"))
     else:
         op.execute("ALTER TABLE connection DROP CONSTRAINT IF EXISTS unique_conn_id")
         # Dropping and recreating cause there's no IF NOT EXISTS
@@ -214,44 +217,45 @@ def upgrade():
         # SQLite does not support DROP CONSTRAINT
         # We have to recreate the table without the constraint
         conn.execute(sa.text("PRAGMA foreign_keys=off"))
-        conn.execute(
-            sa.text("""
-            CREATE TABLE dag_run_new (
-                id INTEGER NOT NULL,
-                dag_id VARCHAR(250) NOT NULL,
-                queued_at TIMESTAMP,
-                execution_date TIMESTAMP NOT NULL,
-                start_date TIMESTAMP,
-                end_date TIMESTAMP,
-                state VARCHAR(50),
-                run_id VARCHAR(250) NOT NULL,
-                creating_job_id INTEGER,
-                external_trigger BOOLEAN,
-                run_type VARCHAR(50) NOT NULL,
-                conf BLOB,
-                data_interval_start TIMESTAMP,
-                data_interval_end TIMESTAMP,
-                last_scheduling_decision TIMESTAMP,
-                dag_hash VARCHAR(32),
-                log_template_id INTEGER,
-                updated_at TIMESTAMP,
-                clear_number INTEGER DEFAULT '0' NOT NULL,
-                CONSTRAINT dag_run_pkey PRIMARY KEY (id),
-                CONSTRAINT dag_run_dag_id_execution_date_key UNIQUE (dag_id, execution_date),
-                CONSTRAINT dag_run_dag_id_run_id_key UNIQUE (dag_id, run_id),
-                CONSTRAINT task_instance_log_template_id_fkey FOREIGN KEY(log_template_id) REFERENCES log_template (id) ON DELETE NO ACTION
+        with contextlib.ExitStack() as exitstack:
+            exitstack.callback(conn.execute, sa.text("PRAGMA foreign_keys=on"))
+            conn.execute(
+                sa.text("""
+                CREATE TABLE dag_run_new (
+                    id INTEGER NOT NULL,
+                    dag_id VARCHAR(250) NOT NULL,
+                    queued_at TIMESTAMP,
+                    execution_date TIMESTAMP NOT NULL,
+                    start_date TIMESTAMP,
+                    end_date TIMESTAMP,
+                    state VARCHAR(50),
+                    run_id VARCHAR(250) NOT NULL,
+                    creating_job_id INTEGER,
+                    external_trigger BOOLEAN,
+                    run_type VARCHAR(50) NOT NULL,
+                    conf BLOB,
+                    data_interval_start TIMESTAMP,
+                    data_interval_end TIMESTAMP,
+                    last_scheduling_decision TIMESTAMP,
+                    dag_hash VARCHAR(32),
+                    log_template_id INTEGER,
+                    updated_at TIMESTAMP,
+                    clear_number INTEGER DEFAULT '0' NOT NULL,
+                    CONSTRAINT dag_run_pkey PRIMARY KEY (id),
+                    CONSTRAINT dag_run_dag_id_execution_date_key UNIQUE (dag_id, execution_date),
+                    CONSTRAINT dag_run_dag_id_run_id_key UNIQUE (dag_id, run_id),
+                    CONSTRAINT task_instance_log_template_id_fkey FOREIGN KEY(log_template_id) REFERENCES log_template (id) ON DELETE NO ACTION
+                )
+            """)
             )
-        """)
-        )
-        headers = (
-            "id, dag_id, queued_at, execution_date, start_date, end_date, state, run_id, creating_job_id, "
-            "external_trigger, run_type, conf, data_interval_start, data_interval_end, "
-            "last_scheduling_decision, dag_hash, log_template_id, updated_at, clear_number"
-        )
-        conn.execute(sa.text(f"INSERT INTO dag_run_new ({headers}) SELECT {headers} FROM dag_run"))
-        conn.execute(sa.text("DROP TABLE dag_run"))
-        conn.execute(sa.text("ALTER TABLE dag_run_new RENAME TO dag_run"))
-        conn.execute(sa.text("PRAGMA foreign_keys=on"))
+            headers = (
+                "id, dag_id, queued_at, execution_date, start_date, end_date, state, run_id, creating_job_id, "
+                "external_trigger, run_type, conf, data_interval_start, data_interval_end, "
+                "last_scheduling_decision, dag_hash, log_template_id, updated_at, clear_number"
+            )
+            conn.execute(sa.text(f"INSERT INTO dag_run_new ({headers}) SELECT {headers} FROM dag_run"))
+            conn.execute(sa.text("DROP TABLE dag_run"))
+            conn.execute(sa.text("ALTER TABLE dag_run_new RENAME TO dag_run"))
         with op.batch_alter_table("dag_run") as batch_op:
             batch_op.create_index("dag_id_state", ["dag_id", "state"], if_not_exists=True)
             batch_op.create_index("idx_dag_run_dag_id", ["dag_id"], if_not_exists=True)

--- a/airflow-core/src/airflow/migrations/versions/0041_3_0_0_rename_dataset_as_asset.py
+++ b/airflow-core/src/airflow/migrations/versions/0041_3_0_0_rename_dataset_as_asset.py
@@ -26,6 +26,7 @@ Create Date: 2024-10-02 08:10:01.697128
 
 from __future__ import annotations
 
+import contextlib
 from typing import TYPE_CHECKING
 
 import sqlalchemy as sa
@@ -104,14 +105,14 @@ def _drop_fkey_if_exists(table, constraint_name):
     dialect_name = conn.dialect.name
 
     if dialect_name == "sqlite":
-        # SQLite requires foreign key constraints to be disabled during batch operations
         conn.execute(text("PRAGMA foreign_keys=OFF"))
-        try:
-            with op.batch_alter_table(table, schema=None) as batch_op:
-                batch_op.drop_constraint(op.f(constraint_name), type_="foreignkey")
-        except ValueError:
-            pass
-        conn.execute(text("PRAGMA foreign_keys=ON"))
+        with contextlib.ExitStack() as exitstack:
+            exitstack.callback(conn.execute, text("PRAGMA foreign_keys=ON"))
+            try:
+                with op.batch_alter_table(table, schema=None) as batch_op:
+                    batch_op.drop_constraint(op.f(constraint_name), type_="foreignkey")
+            except ValueError:
+                pass
     elif dialect_name == "mysql":
         mysql_drop_foreignkey_if_exists(constraint_name, table, op)
     else:

--- a/airflow-core/src/airflow/migrations/versions/0082_3_1_0_make_bundle_name_not_nullable.py
+++ b/airflow-core/src/airflow/migrations/versions/0082_3_1_0_make_bundle_name_not_nullable.py
@@ -27,6 +27,8 @@ Create Date: 2025-08-13 04:20:04.155103
 
 from __future__ import annotations
 
+import contextlib
+
 from alembic import op
 from sqlalchemy.sql import text
 
@@ -44,6 +46,8 @@ airflow_version = "3.1.0"
 def upgrade():
     """Make bundle_name not nullable."""
     dialect_name = op.get_bind().dialect.name
+    exitstack = contextlib.ExitStack()
+
     if dialect_name == "postgresql":
         op.execute(
             text("""
@@ -63,49 +67,47 @@ def upgrade():
         )
     if dialect_name == "sqlite":
         op.execute(text("PRAGMA foreign_keys=OFF"))
-        op.execute(
-            text("""
-                    INSERT OR IGNORE INTO dag_bundle (name) VALUES
-                    ('example_dags'),
-                    ('dags-folder');
-                    """)
-        )
+        exitstack.callback(op.execute, text("PRAGMA foreign_keys=ON"))
 
-    conn = op.get_bind()
-    with ignore_sqlite_value_error(), op.batch_alter_table("dag", schema=None) as batch_op:
-        conn.execute(
-            text(
-                """
-                UPDATE dag
-                SET bundle_name =
-                    CASE
-                        WHEN fileloc LIKE '%/airflow/example_dags/%' THEN 'example_dags'
-                        ELSE 'dags-folder'
-                    END
-                WHERE bundle_name IS NULL
-                """
+    with exitstack:
+        if dialect_name == "sqlite":
+            op.execute(
+                text("""
+                        INSERT OR IGNORE INTO dag_bundle (name) VALUES
+                        ('example_dags'),
+                        ('dags-folder');
+                        """)
             )
-        )
-        # drop the foreign key temporarily and recreate it once both columns are changed
-        batch_op.drop_constraint(batch_op.f("dag_bundle_name_fkey"), type_="foreignkey")
-        batch_op.alter_column("bundle_name", nullable=False, existing_type=StringID())
 
-    with op.batch_alter_table("dag_bundle", schema=None) as batch_op:
-        batch_op.alter_column("name", nullable=False, existing_type=StringID())
+        conn = op.get_bind()
+        with ignore_sqlite_value_error(), op.batch_alter_table("dag", schema=None) as batch_op:
+            conn.execute(
+                text(
+                    """
+                    UPDATE dag
+                    SET bundle_name =
+                        CASE
+                            WHEN fileloc LIKE '%/airflow/example_dags/%' THEN 'example_dags'
+                            ELSE 'dags-folder'
+                        END
+                    WHERE bundle_name IS NULL
+                    """
+                )
+            )
+            batch_op.drop_constraint(batch_op.f("dag_bundle_name_fkey"), type_="foreignkey")
+            batch_op.alter_column("bundle_name", nullable=False, existing_type=StringID())
 
-    with op.batch_alter_table("dag", schema=None) as batch_op:
-        batch_op.create_foreign_key(
-            batch_op.f("dag_bundle_name_fkey"), "dag_bundle", ["bundle_name"], ["name"]
-        )
+        with op.batch_alter_table("dag_bundle", schema=None) as batch_op:
+            batch_op.alter_column("name", nullable=False, existing_type=StringID())
 
-    if dialect_name == "sqlite":
-        op.execute(text("PRAGMA foreign_keys=ON"))
+        with op.batch_alter_table("dag", schema=None) as batch_op:
+            batch_op.create_foreign_key(
+                batch_op.f("dag_bundle_name_fkey"), "dag_bundle", ["bundle_name"], ["name"]
+            )
 
 
 def downgrade():
     """Make bundle_name nullable."""
-    import contextlib
-
     dialect_name = op.get_bind().dialect.name
     exitstack = contextlib.ExitStack()
 

--- a/airflow-core/src/airflow/migrations/versions/0084_3_1_0_add_last_parse_duration_to_dag_model.py
+++ b/airflow-core/src/airflow/migrations/versions/0084_3_1_0_add_last_parse_duration_to_dag_model.py
@@ -27,6 +27,8 @@ Create Date: 2025-08-20 15:53:26.138686
 
 from __future__ import annotations
 
+import contextlib
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy import text
@@ -49,13 +51,12 @@ def downgrade():
     """Unapply add last_parse_duration to dag model."""
     conn = op.get_bind()
     dialect_name = conn.dialect.name
+    exitstack = contextlib.ExitStack()
 
     if dialect_name == "sqlite":
-        # SQLite requires foreign key constraints to be disabled during batch operations
         conn.execute(text("PRAGMA foreign_keys=OFF"))
-        with op.batch_alter_table("dag", schema=None) as batch_op:
-            batch_op.drop_column("last_parse_duration")
-        conn.execute(text("PRAGMA foreign_keys=ON"))
-    else:
+        exitstack.callback(conn.execute, text("PRAGMA foreign_keys=ON"))
+
+    with exitstack:
         with op.batch_alter_table("dag", schema=None) as batch_op:
             batch_op.drop_column("last_parse_duration")

--- a/airflow-core/src/airflow/migrations/versions/0101_3_2_0_ui_improvements_for_deadlines.py
+++ b/airflow-core/src/airflow/migrations/versions/0101_3_2_0_ui_improvements_for_deadlines.py
@@ -30,6 +30,7 @@ Create Date: 2025-10-17 16:04:55.016272
 
 from __future__ import annotations
 
+import contextlib
 import json
 import zlib
 from collections import defaultdict
@@ -98,49 +99,49 @@ def upgrade() -> None:
 
     conn = op.get_bind()
     dialect_name = conn.dialect.name
+    exitstack = contextlib.ExitStack()
 
     if dialect_name == "sqlite":
         conn.execute(sa.text("PRAGMA foreign_keys=OFF"))
+        exitstack.callback(conn.execute, sa.text("PRAGMA foreign_keys=ON"))
 
-    with op.batch_alter_table("deadline", schema=None) as batch_op:
-        batch_op.add_column(sa.Column("deadline_alert_id", sa.Uuid(), nullable=True))
-        batch_op.add_column(sa.Column("created_at", UtcDateTime, nullable=True))
-        batch_op.add_column(sa.Column("last_updated_at", UtcDateTime, nullable=True))
-        batch_op.create_foreign_key(
-            batch_op.f("deadline_deadline_alert_id_fkey"),
-            "deadline_alert",
-            ["deadline_alert_id"],
-            ["id"],
-            ondelete="SET NULL",
+    with exitstack:
+        with op.batch_alter_table("deadline", schema=None) as batch_op:
+            batch_op.add_column(sa.Column("deadline_alert_id", sa.Uuid(), nullable=True))
+            batch_op.add_column(sa.Column("created_at", UtcDateTime, nullable=True))
+            batch_op.add_column(sa.Column("last_updated_at", UtcDateTime, nullable=True))
+            batch_op.create_foreign_key(
+                batch_op.f("deadline_deadline_alert_id_fkey"),
+                "deadline_alert",
+                ["deadline_alert_id"],
+                ["id"],
+                ondelete="SET NULL",
+            )
+
+        # For migration/backcompat purposes if no timestamp is there from the migration, use now()
+        # then lock the columns down so all new entries require the timestamps to be provided.
+        now = timezone.utcnow()
+        conn.execute(
+            sa.text("""
+                UPDATE deadline
+                SET created_at = :now, last_updated_at = :now
+                WHERE created_at IS NULL OR last_updated_at IS NULL
+            """),
+            {"now": now},
         )
 
-    # For migration/backcompat purposes if no timestamp is there from the migration, use now()
-    # then lock the columns down so all new entries require the timestamps to be provided.
-    now = timezone.utcnow()
-    conn.execute(
-        sa.text("""
-            UPDATE deadline
-            SET created_at = :now, last_updated_at = :now
-            WHERE created_at IS NULL OR last_updated_at IS NULL
-        """),
-        {"now": now},
-    )
+        with op.batch_alter_table("deadline", schema=None) as batch_op:
+            batch_op.alter_column("created_at", existing_type=UtcDateTime, nullable=False)
+            batch_op.alter_column("last_updated_at", existing_type=UtcDateTime, nullable=False)
 
-    with op.batch_alter_table("deadline", schema=None) as batch_op:
-        batch_op.alter_column("created_at", existing_type=UtcDateTime, nullable=False)
-        batch_op.alter_column("last_updated_at", existing_type=UtcDateTime, nullable=False)
-
-    with op.batch_alter_table("deadline_alert", schema=None) as batch_op:
-        batch_op.create_foreign_key(
-            batch_op.f("deadline_alert_serialized_dag_id_fkey"),
-            "serialized_dag",
-            ["serialized_dag_id"],
-            ["id"],
-            ondelete="CASCADE",
-        )
-
-    if dialect_name == "sqlite":
-        conn.execute(sa.text("PRAGMA foreign_keys=ON"))
+        with op.batch_alter_table("deadline_alert", schema=None) as batch_op:
+            batch_op.create_foreign_key(
+                batch_op.f("deadline_alert_serialized_dag_id_fkey"),
+                "serialized_dag",
+                ["serialized_dag_id"],
+                ["id"],
+                ondelete="CASCADE",
+            )
 
     migrate_existing_deadline_alert_data_from_serialized_dag()
 
@@ -151,21 +152,21 @@ def downgrade() -> None:
 
     conn = op.get_bind()
     dialect_name = conn.dialect.name
+    exitstack = contextlib.ExitStack()
 
     if dialect_name == "sqlite":
         conn.execute(sa.text("PRAGMA foreign_keys=OFF"))
+        exitstack.callback(conn.execute, sa.text("PRAGMA foreign_keys=ON"))
 
-    with op.batch_alter_table("deadline", schema=None) as batch_op:
-        batch_op.drop_constraint(batch_op.f("deadline_deadline_alert_id_fkey"), type_="foreignkey")
-        batch_op.drop_column("deadline_alert_id")
-        batch_op.drop_column("last_updated_at")
-        batch_op.drop_column("created_at")
+    with exitstack:
+        with op.batch_alter_table("deadline", schema=None) as batch_op:
+            batch_op.drop_constraint(batch_op.f("deadline_deadline_alert_id_fkey"), type_="foreignkey")
+            batch_op.drop_column("deadline_alert_id")
+            batch_op.drop_column("last_updated_at")
+            batch_op.drop_column("created_at")
 
-    with op.batch_alter_table("deadline_alert", schema=None) as batch_op:
-        batch_op.drop_constraint(batch_op.f("deadline_alert_serialized_dag_id_fkey"), type_="foreignkey")
-
-    if dialect_name == "sqlite":
-        conn.execute(sa.text("PRAGMA foreign_keys=ON"))
+        with op.batch_alter_table("deadline_alert", schema=None) as batch_op:
+            batch_op.drop_constraint(batch_op.f("deadline_alert_serialized_dag_id_fkey"), type_="foreignkey")
 
     op.drop_table("deadline_alert")
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fix: Ensure SQLite foreign key pragmas are always restored

Refactors several migration scripts to use `contextlib.ExitStack()` for managing `PRAGMA foreign_keys=OFF` and `PRAGMA foreign_keys=ON` statements in SQLite.

This change ensures that `PRAGMA foreign_keys=ON` is reliably executed, even if an exception occurs during the migration step. This prevents potential database inconsistencies by guaranteeing that foreign key constraints are re-enabled after temporary disabling.

The following migration files were updated:
- `0017_2_9_2_fix_inconsistency_between_ORM_and_migration_files.py`
- `0041_3_0_0_rename_dataset_as_asset.py`
- `0082_3_1_0_make_bundle_name_not_nullable.py`
- `0084_3_1_0_add_last_parse_duration_to_dag_model.py`
- `0101_3_2_0_ui_improvements_for_deadlines.py`

This improves the robustness and reliability of Airflow's SQLite migrations.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Custom GPT following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.

<div><a href="https://cursor.com/agents/bc-57abadad-1d42-4444-8be9-67d8dee21ad7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-57abadad-1d42-4444-8be9-67d8dee21ad7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->